### PR TITLE
fix: inconsistent workflow job names

### DIFF
--- a/.github/workflows/deploy-tool-json-browser.yml
+++ b/.github/workflows/deploy-tool-json-browser.yml
@@ -8,7 +8,7 @@
 
 # It relies on the `FIREBASE_TOKEN` secret being available in this repo.
 
-name: deploy-json-browser
+name: deploy-tool-json-browser
 
 on:
   push:

--- a/.github/workflows/deploy-tool-json-formatter.yml
+++ b/.github/workflows/deploy-tool-json-formatter.yml
@@ -8,7 +8,7 @@
 
 # It relies on the `FIREBASE_TOKEN` secret being available in this repo.
 
-name: deploy-json-formatter
+name: deploy-tool-json-formatter
 
 on:
   push:

--- a/.github/workflows/deploy-tool-markdown-renderer.yml
+++ b/.github/workflows/deploy-tool-markdown-renderer.yml
@@ -8,7 +8,7 @@
 
 # It relies on the `FIREBASE_TOKEN` secret being available in this repo.
 
-name: deploy-markdown-renderer
+name: deploy-tool-markdown-renderer
 
 on:
   push:

--- a/.github/workflows/deploy-tool-number-converter.yml
+++ b/.github/workflows/deploy-tool-number-converter.yml
@@ -8,7 +8,7 @@
 
 # It relies on the `FIREBASE_TOKEN` secret being available in this repo.
 
-name: deploy-number-converter
+name: deploy-tool-number-converter
 
 on:
   push:


### PR DESCRIPTION
As the title says. Ensures all tool workflow names follow the pattern `{{job}}-tool-{{tool-name}}`.

![whoops](https://user-images.githubusercontent.com/2746248/75500034-c6619480-59c3-11ea-8488-b56322b632ab.gif)