### PR TITLE
feat: add status badges to the Readme

### DIFF
--- a/.project/scripts/new-tool-script/template/tool/README.md
+++ b/.project/scripts/new-tool-script/template/tool/README.md
@@ -12,6 +12,7 @@
 - [ ] ensure any remaining #TODOs in this folder / file have been completed
 - [ ] update the website to include your tool in the list of tools
 - [ ] update /tools README.md to include your tool in the list of tools
+- [ ] update the main readme to include a status badge for your tool
 - [ ] submit as a PR for review =D
 - [ ] add the completed tool as a subdomain in Google hosting panel. We want to configure entries for both `tool-name.holistic-toolbox.com` and `www.tool-name.holistic-toolbox.com`.
 - [ ] in the firebase console, configure the new site to use these new domains

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A collection of useful tools, to service all areas of development. Hosted at htt
 ![website](https://github.com/holistic-web/toolbox/workflows/deploy-website/badge.svg)]
 ![layout](https://github.com/holistic-web/toolbox/workflows/publish-layout/badge.svg)]
 ![layout-stories](https://github.com/holistic-web/toolbox/workflows/deploy-layout-stories/badge.svg)]
+
 ![image-comparer](https://github.com/holistic-web/toolbox/workflows/deploy-tool-image-comparer/badge.svg)]
 ![json-browser](https://github.com/holistic-web/toolbox/workflows/deploy-tool-json-browser/badge.svg)]
 ![json-diff](https://github.com/holistic-web/toolbox/workflows/deploy-tool-json-diff/badge.svg)]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 A collection of useful tools, to service all areas of development. Hosted at https://holistic-toolbox.com
 
+![website](https://github.com/holistic-web/toolbox/workflows/deploy-website/badge.svg)]
+![layout](https://github.com/holistic-web/toolbox/workflows/publish-layout/badge.svg)]
+![layout-stories](https://github.com/holistic-web/toolbox/workflows/publish-layout-stories/badge.svg)]
+![image-comparer](https://github.com/holistic-web/toolbox/workflows/image-comparer/badge.svg)]
+![json-browser](https://github.com/holistic-web/toolbox/workflows/deploy-tool-json-browser/badge.svg)]
+![json-diff](https://github.com/holistic-web/toolbox/workflows/deploy-tool-json-diff/badge.svg)]
+![json-formatter](https://github.com/holistic-web/toolbox/workflows/deploy-tool-json-formatter/badge.svg)]
+![markdown-renderer](https://github.com/holistic-web/toolbox/workflows/deploy-tool-markdown-renderer/badge.svg)]
+![nlp-toolkit](https://github.com/holistic-web/toolbox/workflows/deploy-tool-nlp-toolkit/badge.svg)]
+![number-converter](https://github.com/holistic-web/toolbox/workflows/deploy-tool-number-converter/badge.svg)]
+
 Check [.project/analytics.md](/.project/analytics.md) for analytics information
 
 ## Contents

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ A collection of useful tools, to service all areas of development. Hosted at htt
 
 ![website](https://github.com/holistic-web/toolbox/workflows/deploy-website/badge.svg)]
 ![layout](https://github.com/holistic-web/toolbox/workflows/publish-layout/badge.svg)]
-![layout-stories](https://github.com/holistic-web/toolbox/workflows/publish-layout-stories/badge.svg)]
-![image-comparer](https://github.com/holistic-web/toolbox/workflows/image-comparer/badge.svg)]
+![layout-stories](https://github.com/holistic-web/toolbox/workflows/deploy-layout-stories/badge.svg)]
+![image-comparer](https://github.com/holistic-web/toolbox/workflows/deploy-tool-image-comparer/badge.svg)]
 ![json-browser](https://github.com/holistic-web/toolbox/workflows/deploy-tool-json-browser/badge.svg)]
 ![json-diff](https://github.com/holistic-web/toolbox/workflows/deploy-tool-json-diff/badge.svg)]
 ![json-formatter](https://github.com/holistic-web/toolbox/workflows/deploy-tool-json-formatter/badge.svg)]


### PR DESCRIPTION
## What?
- Adds status badges to the readme showing the status of the most recent deployment / publishing workflow for each project

## Why?
- To have status badges for each project on the readme. 🎈 

![image](https://user-images.githubusercontent.com/2746248/75500829-f7db5f80-59c5-11ea-89fc-7ab70fa6f030.png)

## Before merging
- [x] The errors in the above image are due to some workflows having inconsistent names, we need to merge #86 to fix that