### PR TITLE
chore: add factsheet table to readme files

### DIFF
--- a/.project/scripts/new-tool-script/README.md
+++ b/.project/scripts/new-tool-script/README.md
@@ -1,7 +1,12 @@
 # New Tool Script
+This script generates a new tool for the toolbox.
 
-This script generates a new tool for the toolbox. To generate a tool:
+## Factsheet
+| **Category**     | **Value**     |
+|------------------|---------------|
+| **Project Type** | Helper Script |
 
+## Generating a Tool
 1. open `config.js` from within this folder and set the values you'd like to use
 
 2. run the following from within this folder

--- a/.project/scripts/new-tool-script/template/tool/README.md
+++ b/.project/scripts/new-tool-script/template/tool/README.md
@@ -1,8 +1,14 @@
 # {{tool-name-human}}
 
-#TODO: add a brief description of this tool and any key packages it uses
+#TODO: add a brief description of this tool hrere
 
-#TODO: provide a link to the live url of this tool
+## Factsheet
+| **Category**            | **Value**     |
+|-------------------------|---------------|
+| **Project Type**        | Tool: Web App |
+| **Live URL**            | #TODO         |
+| **Firebase Site Name**  | #TODO         |
+| **Unique Dependencies** | #TODO         |
 
 ## Setup Guide
 - [ ] run `npm install` on this folder to generate package-lock.json and node_modules

--- a/.project/scripts/new-tool-script/template/tool/README.md
+++ b/.project/scripts/new-tool-script/template/tool/README.md
@@ -1,6 +1,5 @@
 # {{tool-name-human}}
-
-#TODO: add a brief description of this tool hrere
+#TODO: add a brief description of this tool here
 
 ## Factsheet
 | **Category**            | **Value**     |

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # Holistic Toolbox
-
 A collection of useful tools, to service all areas of development. Hosted at https://holistic-toolbox.com
 
 ![website](https://github.com/holistic-web/toolbox/workflows/deploy-website/badge.svg)]

--- a/layout/README.md
+++ b/layout/README.md
@@ -1,9 +1,12 @@
 # Toolbox Layout
 This is a shared [Vue.js](https://vuejs.org) component library for use in the Toolbox. [Boostrap Vue](https://bootstrap-vue.js.org/) is used to drive the core of the functionality. It also includes firebase and our [analytics configurations](/.project/analytics.md).
 
-It is published on npm at: https://www.npmjs.com/package/@holistic-web/toolbox-layout
-
-A demo can be found here: https://toolbox-layout-stories.firebaseapp.com
+## Factsheet
+| **Category**     | **Value**                              |
+|------------------|----------------------------------------|
+| **Project Type** | Component Library                      |
+| **Package Name** | @holistic-web/toolbox-layout           |
+| **Demo URL**     | https://toolbox-layout-stories.web.app |
 
 ## Usage
 To use this library in a Vue app, simply include:

--- a/tools/image-comparer/README.md
+++ b/tools/image-comparer/README.md
@@ -1,8 +1,13 @@
 # Image Comparer
+This tool provides a visual comparison of two image files.
 
-This tool provides a visual comparison of two image files. The comparison is powered by the [pixelmatch](https://www.npmjs.com/package/pixelmatch) package.
-
-Hosted at http://image-comparer.holistic-toolbox.com
+## Factsheet
+| **Category**            | **Value**                                   |
+|-------------------------|---------------------------------------------|
+| **Project Type**        | Tool: Web App                               |
+| **Live URL**            | https://image-comparer.holistic-toolbox.com |
+| **Firebase Site Name**  | image-comparer                              |
+| **Unique Dependencies** | pixelmatch                                  |
 
 ## Development
 To develop for this project:

--- a/tools/json-browser/README.md
+++ b/tools/json-browser/README.md
@@ -1,10 +1,13 @@
 # JSON Browser
-
 This is a tool to view and browse json in a useful way. Good for those who need to analyse a lot of data stored in a JSON format.
 
-It is powered by [vue-json-pretty](https://www.npmjs.com/package/vue-json-pretty).
-
-Hosted at http://json-browser.holistic-toolbox.com
+## Factsheet
+| **Category**            | **Value**                                  |
+|-------------------------|--------------------------------------------|
+| **Project Type**        | Tool: Web App                              |
+| **Live URL**            | https://json-browser.holistic-toolbox.com  |
+| **Firebase Site Name**  | json-browser                               |
+| **Unique Dependencies** | vue-json-pretty, vue-router, vue-clipboard |
 
 ## Functionality
 Along with JSON browsing, this tool supports:

--- a/tools/json-diff/README.md
+++ b/tools/json-diff/README.md
@@ -1,8 +1,13 @@
 # JSON Diff
+This is tool to highlight the differences between two JSON objects.
 
-This is tool compares two JSON objects using the library [jsondiffpatch](https://www.npmjs.com/package/jsondiffpatch).
-
-Hosted at https://json-diff.holistic-toolbox.com
+## Factsheet
+| **Category**            | **Value**                              |
+|-------------------------|----------------------------------------|
+| **Project Type**        | Tool: Web App                          |
+| **Live URL**            | https://json-diff.holistic-toolbox.com |
+| **Firebase Site Name**  | json-diff                              |
+| **Unique Dependencies** | jsondiffpatch                          |
 
 ## Development
 To develop for this project:

--- a/tools/json-formatter/README.md
+++ b/tools/json-formatter/README.md
@@ -4,10 +4,16 @@ This tool validates and formats JSON entered by a developer. It is written in Vu
 
 The JSON rendering is done with the built in [`JSON.stringify(...)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) method.
 
-Hosted at https://json-formatter.holistic-toolbox.com
+## Factsheet
+| **Category**            | **Value**                                   |
+|-------------------------|---------------------------------------------|
+| **Project Type**        | Tool: Web App                               |
+| **Live URL**            | https://json-formatter.holistic-toolbox.com |
+| **Firebase Site Name**  | json-formatter                              |
+| **Unique Dependencies** | _none_                                      |
 
 ## Functionality
-Along with JSON formatting, this tool supports:
+Along with formatting JSON files, this tool supports:
 - browsing the formatted JSON with a link to json-formatter
 
 ## Development

--- a/tools/markdown-renderer/README.md
+++ b/tools/markdown-renderer/README.md
@@ -1,8 +1,14 @@
 # Markdown Renderer
 
-This tool renders markdown using the [marked](https://www.npmjs.com/package/marked) package with some custom styling.
+This tool instantly renders any markdown entered on the page.
 
-Hosted at: https://markdown-renderer.holistic-toolbox.com
+## Factsheet
+| **Category**            | **Value**                                      |
+|-------------------------|------------------------------------------------|
+| **Project Type**        | Tool: Web App                                  |
+| **Live URL**            | https://markdown-renderer.holistic-toolbox.com |
+| **Firebase Site Name**  | markdown-renderer-4e49f                        |
+| **Unique Dependencies** | marked                                         |
 
 ## Development
 To develop for this project:

--- a/tools/nlp-toolkit/README.md
+++ b/tools/nlp-toolkit/README.md
@@ -1,8 +1,14 @@
 # NLP Toolkit
 
-This is a tool to to perform NLP operations using the library [compromise](https://www.npmjs.com/package/compromise). Currently supports past and future tense conversion plus a simple function to negate statements.
+This is a tool to to perform simple NLP operations. It currently supports past and future tense conversion plus a simple function to negate statements.
 
-Hosted at https://nlp-toolkit.holistic-toolbox.com/
+## Factsheet
+| **Category**            | **Value**                                |
+|-------------------------|------------------------------------------|
+| **Project Type**        | Tool: Web App                            |
+| **Live URL**            | https://nlp-toolkit.holistic-toolbox.com |
+| **Firebase Site Name**  | nlp-toolkit                              |
+| **Unique Dependencies** | compromise                               |
 
 ## Development
 To develop for this project:

--- a/tools/number-converter/README.md
+++ b/tools/number-converter/README.md
@@ -13,7 +13,6 @@ Hosted at: https://number-converter.web.app/
 | **Firebase Site Name**  | number-converter                              |
 | **Unique Dependencies** | _none_                                        |
 
-
 ## Development
 To develop for this project:
 1. Install dependencies

--- a/tools/number-converter/README.md
+++ b/tools/number-converter/README.md
@@ -5,6 +5,15 @@ Number converting done via: [int.toString(Base)](https://developer.mozilla.org/e
 
 Hosted at: https://number-converter.web.app/
 
+## Factsheet
+| **Category**            | **Value**                                     |
+|-------------------------|-----------------------------------------------|
+| **Project Type**        | Tool: Web App                                 |
+| **Live URL**            | https://number-converter.holistic-toolbox.com |
+| **Firebase Site Name**  | number-converter                              |
+| **Unique Dependencies** | _none_                                        |
+
+
 ## Development
 To develop for this project:
 1. Install dependencies

--- a/website/README.md
+++ b/website/README.md
@@ -1,8 +1,12 @@
 # Website
+This is the homepage for all Holistic Toolbox tools.
 
-This is the homepage for all Holistic Toolbox tools
-
-Hosted at: https://holistic-toolbox.com
+## Factsheet
+| **Category**            | **Value**                    |
+|-------------------------|----------------------------- |
+| **Project Type**        | Website: Web App             |
+| **Live URL**            | https://holistic-toolbox.com |
+| **Firebase Site Name**  | holistic-toolbox             |
 
 ## Development
 To develop for this project:


### PR DESCRIPTION
It helps if there is a consistent factsheet at the top of each project so people can know where to expect to find certain information. This PR adds that.

Conveniently this should also trigger all our tools to be redeployed so should also fix the issue we have with broken tags on the front page of our github repo:
![Screenshot 2020-03-12 at 00 21 11](https://user-images.githubusercontent.com/2746248/76475656-9371c480-63f7-11ea-826c-a9ce04213e03.png)
