### PR TITLE
fix: don't lint image-comparer on master branch

### DIFF
--- a/.github/workflows/lint-tool-image-comparer.yml
+++ b/.github/workflows/lint-tool-image-comparer.yml
@@ -11,6 +11,8 @@ name: lint-tool-image-comparer
 
 on:
   push:
+    branches-ignore:
+    - master
     paths:
     - 'tools/image-comparer/**'
 


### PR DESCRIPTION
This is to be consistent with our other tools, see: https://github.com/holistic-web/toolbox/blob/master/.github/workflows/lint-tool-json-diff.yml#L12-L17