### PR TITLE
fix: ToolMarkdown code colour

### DIFF
--- a/layout/README.md
+++ b/layout/README.md
@@ -58,7 +58,5 @@ _Remember to increment the version number in package.json_
 - This project uses [storybook](https://storybook.js.org/) to provide visual documentation. This storybook deployment is released automatically by the `/.github/workflows/deploy-layout-stories` action.
 
 ## Roadmap
-- allow including a reset / main action button with configuration rather than slots
-- swap the tool name and toolbox branding positions in the header
 - see about resolving the scroll issue, if at all possible
 - add breakpoints to the storybook examples

--- a/layout/src/components/ToolMarkdown.vue
+++ b/layout/src/components/ToolMarkdown.vue
@@ -1,5 +1,5 @@
 <template>
-	<section v-html="renderedMarkdown"/>
+	<section class="ToolMarkdown" v-html="renderedMarkdown"/>
 </template>
 
 <script>
@@ -31,3 +31,14 @@ export default {
 
 };
 </script>
+
+<style lang="scss">
+@import '../styles/theme';
+
+.ToolMarkdown {
+	pre code {
+		color: $primary;
+	}
+}
+
+</style>

--- a/tools/json-browser/README.md
+++ b/tools/json-browser/README.md
@@ -42,3 +42,6 @@ Manual deployment is not recommended but in case we ever need to do the followin
 ## Road Map
 - load JSON data from http source
 - allow a URL query to provide the JSON string so you can be linked here from another app
+
+## Bugs
+- get shareable link doesn't work for multi line JSONs


### PR DESCRIPTION
Fixes the colour for code marked by three backticks ('`') to be more visible against the background. Part of #92

## Before
![Screenshot 2020-03-13 at 22 11 31](https://user-images.githubusercontent.com/2746248/76663008-9c899f80-6577-11ea-8a55-33a792980ce3.png)

## After
![Screenshot 2020-03-13 at 22 09 54](https://user-images.githubusercontent.com/2746248/76662998-94316480-6577-11ea-93b5-1d526b521593.png)
