### PR TITLE
fix: marked santize console warning

### DIFF
--- a/layout/src/components/ToolMarkdown.vue
+++ b/layout/src/components/ToolMarkdown.vue
@@ -19,7 +19,11 @@ export default {
 	},
 	methods: {
 		renderMarkdown() {
-			this.renderedMarkdown = marked(this.markdown, { sanitize: true });
+			this.renderedMarkdown = marked(this.markdown, {
+				// https://marked.js.org/#/USING_ADVANCED.md#options
+				breaks: true,
+				gfm: true
+			});
 		}
 	},
 	mounted() {


### PR DESCRIPTION
Part of #92. This PR also ensures we render using `gfm` (github flavoured markdown)

## Before
![Screenshot 2020-03-14 at 04 02 51](https://user-images.githubusercontent.com/2746248/76674611-42093700-65a9-11ea-8d93-ec625ab9045f.png)

## After
![Screenshot 2020-03-14 at 04 05 06](https://user-images.githubusercontent.com/2746248/76674617-49c8db80-65a9-11ea-9c83-ee62b332380e.png)