### PR TITLE
chore: add js-formatter badge to main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A collection of useful tools, to service all areas of development. Hosted at htt
 ![layout-stories](https://github.com/holistic-web/toolbox/workflows/deploy-layout-stories/badge.svg)
 
 ![image-comparer](https://github.com/holistic-web/toolbox/workflows/deploy-tool-image-comparer/badge.svg)
+![js-formatter](https://github.com/holistic-web/toolbox/workflows/deploy-tool-js-formatter/badge.svg)
 ![json-browser](https://github.com/holistic-web/toolbox/workflows/deploy-tool-json-browser/badge.svg)
 ![json-diff](https://github.com/holistic-web/toolbox/workflows/deploy-tool-json-diff/badge.svg)
 ![json-formatter](https://github.com/holistic-web/toolbox/workflows/deploy-tool-json-formatter/badge.svg)


### PR DESCRIPTION
As the title says.

![badge-example](https://media.giphy.com/media/l0HlKPUXoHOwkmp4k/giphy.gif)